### PR TITLE
python path

### DIFF
--- a/aur/ceph-git/PKGBUILD
+++ b/aur/ceph-git/PKGBUILD
@@ -66,7 +66,7 @@ build() {
   cd "${srcdir}/${pkgname%%-git}"
 
   ./autogen.sh
-  LIBS="-lpthread -lboost_system" PYTHON=/usr/bin/python2 LDFLAGS="" ./configure \
+  LIBS="-lpthread -lboost_system" PYTHON=python2 LDFLAGS="" ./configure \
     --prefix=/usr \
     --sysconfdir=/etc \
     --with-radosgw


### PR DESCRIPTION
Ceph's configure script expects the `PYTHON` environment variable to be just a command name not a full path because it manually searches `$PATH` for it, causing the build to fail like this:

```
configure: error: in `/home/karl/.cache/pacaur/ceph-git/src/ceph':
configure: error: "/usr/bin/python2"-config not found
```
